### PR TITLE
Hue bridge register fix

### DIFF
--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/NetworkMethods.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/NetworkMethods.java
@@ -99,14 +99,12 @@ public class NetworkMethods {
 
   public static void PreformRegister(RequestQueue queue,
                                      Listener<RegistrationResponse[]>[] listeners, Bridge[] bridges,
-                                     String username,
                                      String deviceType) {
     if (queue == null || bridges == null) {
       return;
     }
     Gson gson = new Gson();
     RegistrationRequest request = new RegistrationRequest();
-    request.username = username;
     request.devicetype = deviceType;
     String registrationRequest = gson.toJson(request);
 

--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/RegistrationRequest.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/RegistrationRequest.java
@@ -1,8 +1,6 @@
 package com.kuxhausen.huemore.net.hue.api;
 
 public class RegistrationRequest {
-
-  public String username;
   public String devicetype;
 
   public RegistrationRequest() {

--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/RegistrationResponse.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/RegistrationResponse.java
@@ -13,6 +13,10 @@ public class RegistrationResponse {
   }
 
   public class ResponseSuccess {
+    private String username;
 
+    public String getUsername() {
+      return username;
+    }
   }
 }

--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/RegisterWithHubDialogFragment.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/RegisterWithHubDialogFragment.java
@@ -91,8 +91,7 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
           progressBar
               .setProgress((int) (((length_in_milliseconds - millisUntilFinished) * 100.0)
                                   / length_in_milliseconds));
-          NetworkMethods.PreformRegister(rq, getListeners(getUserName()), bridges, getUserName(),
-                                         getDeviceType());
+          NetworkMethods.PreformRegister(rq, getListeners(), bridges, getDeviceType());
         }
       }
 
@@ -100,8 +99,7 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
       public void onFinish() {
         if (isAdded()) {
           // try one last time
-          NetworkMethods.PreformRegister(rq, getListeners(getUserName()), bridges, getUserName(),
-                                         getDeviceType());
+          NetworkMethods.PreformRegister(rq, getListeners(), bridges, getDeviceType());
 
           // launch the failed registration dialog
           RegistrationFailDialogFragment rfdf = new RegistrationFailDialogFragment();
@@ -116,11 +114,11 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
     return builder.create();
   }
 
-  protected Listener<RegistrationResponse[]>[] getListeners(String username) {
+  protected Listener<RegistrationResponse[]>[] getListeners() {
     Listener<RegistrationResponse[]>[] listeners = new Listener[bridges.length];
     for (int i = 0; i < bridges.length; i++) {
       if (bridges[i] != null && bridges[i].internalipaddress != null) {
-        listeners[i] = new RegistrationListener(bridges[i].internalipaddress, username);
+        listeners[i] = new RegistrationListener(bridges[i].internalipaddress);
       }
     }
     return listeners;
@@ -133,24 +131,6 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
     onDestroyView();
   }
 
-  public String getUserName() {
-
-    try {
-      MessageDigest md;
-      String serialID = Settings.Secure.ANDROID_ID;
-      md = MessageDigest.getInstance(InternalArguments.MD5);
-      String resultString = new BigInteger(1, md.digest(serialID.getBytes())).toString(16);
-
-      return resultString;
-    } catch (NoSuchAlgorithmException e) {
-
-      e.printStackTrace();
-    }
-
-    // fall back on hash of hueMore if android ID fails
-    return InternalArguments.FALLBACK_USERNAME_HASH;
-  }
-
   public String getDeviceType() {
     return getString(R.string.app_name);
   }
@@ -158,11 +138,11 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
   class RegistrationListener implements Listener<RegistrationResponse[]> {
 
     public String bridgeIP;
-    public String username;
+    //public String username;
 
-    public RegistrationListener(String ip, String userName) {
+    public RegistrationListener(String ip) {
       bridgeIP = ip;
-      username = userName;
+      //username = userName;
     }
 
     @Override
@@ -185,7 +165,7 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
           } else {
             mHubData.localHubAddress = bridgeIP;
           }
-          mHubData.hashedUsername = username;
+          mHubData.hashedUsername = response[0].success.getUsername();
           ContentValues cv = new ContentValues();
 
           cv.put(Definitions.NetConnectionColumns.TYPE_COLUMN,

--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/RegisterWithHubDialogFragment.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/RegisterWithHubDialogFragment.java
@@ -138,11 +138,9 @@ public class RegisterWithHubDialogFragment extends DialogFragment {
   class RegistrationListener implements Listener<RegistrationResponse[]> {
 
     public String bridgeIP;
-    //public String username;
 
     public RegistrationListener(String ip) {
       bridgeIP = ip;
-      //username = userName;
     }
 
     @Override


### PR DESCRIPTION
No longer send username with request - use generated username received from response instead. The bridge registration can now complete.

Resolves #108.