### PR TITLE
Option to allow Doze

### DIFF
--- a/mobile/src/main/java/com/kuxhausen/huemore/DisableDozeDialogFragment.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/DisableDozeDialogFragment.java
@@ -5,10 +5,12 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
+import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
@@ -34,11 +36,20 @@ public class DisableDozeDialogFragment extends DialogFragment {
    * @return true if on M+ device and not currently exempted from Doze mode
    */
   public static boolean needsDozeOptOut(Context context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    boolean ignoreDoze = prefs.getBoolean(context.getString(R.string.preference_ignore_doze), false);
+    if (!ignoreDoze && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
       return !pm.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID);
     }
     return false;
+  }
+
+  /**
+   * @return whether this phone supports Doze.
+   */
+  public static boolean systemSupportsDoze() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
   }
 
   public static void showDozeOptOutIfNeeded(AppCompatActivity activity) {

--- a/mobile/src/main/java/com/kuxhausen/huemore/SettingsFragment.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/SettingsFragment.java
@@ -25,6 +25,14 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
       this.getPreferenceScreen().addPreference(preference);
     }
 
+    // Hide the doze option if the phone doesn't support doze.
+    if (!DisableDozeDialogFragment.systemSupportsDoze()) {
+      Preference ignoreDoze = getPreferenceScreen().findPreference(getString(R.string.preference_ignore_doze));
+      if (ignoreDoze != null) {
+          ignoreDoze.setVisible(false);
+      }
+    }
+
     showSelectedLanguage();
 
     Preference buildVersion = getPreferenceScreen().findPreference(

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="settings_use_system_language">Use system language</string>
     <string name="settings_nfc_controls_title">Show NFC quick controls</string>
     <string name="settings_nfc_controls_descriptor">When NFC tags read</string>
+    <string name="settings_ignore_doze_title">Skip foreground check</string>
+    <string name="settings_ignore_doze_descriptor">Only use if you know what you\'re doing. Your phone may cancel long-running moods.</string>
     <string name="settings_category_general">General</string>
     <string name="settings_category_about">About</string>
     <string name="doze_message">LampShade needs permission to run in the background.</string>

--- a/mobile/src/main/res/values/strings_no_translate.xml
+++ b/mobile/src/main/res/values/strings_no_translate.xml
@@ -52,6 +52,7 @@
     <string name="preference_use_system_language">USE_SYSTEM_LANGUAGE</string>
     <string name="preference_user_selected_locale_lang">USER_SELECTED_LOCALE_LANG</string>
     <string name="preference_show_nfc_controls">SHOW_ACTIVITY_ON_NFC_READ</string>
+    <string name="preference_ignore_doze">IGNORE_DOZE</string>
     <string name="preference_social_links">SOCIAL_LINKS</string>
     <string name="preference_build_version">BUILD_VERSION</string>
     <string name="preference_developer_options">DEVELOPER_OPTIONS</string>

--- a/mobile/src/main/res/xml/settings.xml
+++ b/mobile/src/main/res/xml/settings.xml
@@ -17,6 +17,12 @@
             android:summary="@string/settings_nfc_controls_descriptor"
             android:title="@string/settings_nfc_controls_title" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/preference_ignore_doze"
+            android:summary="@string/settings_ignore_doze_descriptor"
+            android:title="@string/settings_ignore_doze_title" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:disableDependentsState="true"


### PR DESCRIPTION
I know Doze can end up cancelling moods in the background when the phone is idle but I think it'd be handy for users who know what they're doing and are sticklers for battery optimization to be able to suppress the startup prompt.

The item in the settings screen could possibly be moved to a separate "Advanced" section away from the normal settings, wasn't sure.